### PR TITLE
Updated terminology, the task assign response and the volume definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,13 @@ The response contains volume objects that contain ids and bounds which are used 
 |:----------------|:------------------------------------|
 | id              | task id                             |
 | seeds           | array of segment ids known to be part of the cell.               |
-| cell | the cell that the task belongs to |
-| channel      | channel [volume object](#volume-object)      |
-| segmentation | segmentation [volume object](#volume-object) |
+| status          | One of the following: <br/> <ul><li>0: NORMAL</li><li>3: TUTORIAL</li><li>6: STASHED (not visible in overview</li><li>10: FROZEN (unplayable)</li><li>11: DUPLICATE (all or part of this cube duplicates with another cube in a different cell)</li></ul>|
+| created         | The date and time when the task was created |
+| cell            | the ID of the cell that the task belongs to |
+| channel_id      | ID of the channel volume |
+| segmentation_id | ID of the segmentation volume |
+| channel         | channel [volume object](#volume-object)      |
+| segmentation    | segmentation [volume object](#volume-object) |
 
 ### Error Responses
 - 404 - no tasks available that fulfill the request, try with a different cell_id or lack of one.
@@ -212,38 +216,81 @@ https://beta.eyewire.org/2.0/tasks/assign?access_token=78q3ja8y
 
 ```json
 {
-  "id": 17444,
-  "seeds": [245, 5025, 6500],
-  "cell": 10,
+  "id": 558593,
+  "seeds": [ 491 ],
+  "status": 0,
+  "created": "2015-01-29T21:18:32.000Z",
+  "cell": 693,
+  "channel_id": 79285,
+  "segmentation_id": 79286,
+  "depth": 33,
+  "right_edge": 1444600,
+  "left_edge": 1444593,
+  "confidence": 1,
+  "underconfidence": 1,
+  "enabled": 1,
+  "weightsum": 0,
+  "lastmodified": "2015-02-04T21:26:28.000Z",
+  "flagged": 0,
+  "complete": 1,
+  "inspected_weight": 1,
+  "notes": "",
+  "completion_votes": 1000000,
   "channel": {
-    "id": 63200,
+    "uri": "/usr/local/omni/data/omelette2/x09/y59/x09y59z21_s2259_13491_4915_e2514_13746_5170.omni.files/",
     "bounds": {
       "min": {
-        "x": 2930,
-        "y": 4082,
-        "z": 6482
+        "x": 2258,
+        "y": 13490,
+        "z": 4914
       },
       "max": {
-        "x": 3186,
-        "y": 4338,
-        "z": 6738
+        "x": 2514,
+        "y": 13746,
+        "z": 5170
       }
-    }
+    },
+    "resolution": {
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "type": 5,
+    "chunkDims": {
+      "x": 128,
+      "y": 128,
+      "z": 128
+    },
+    "vol_type": 1,
+    "mipLevel": 0
   },
-  "segmentation":{
-    "id": 63201,
+  "segmentation": {
+    "uri": "/usr/local/omni/data/omelette2/x09/y59/x09y59z21_s2259_13491_4915_e2514_13746_5170.omni.files/",
     "bounds": {
       "min": {
-        "x": 2930,
-        "y": 4082,
-        "z": 6482
+        "x": 2258,
+        "y": 13490,
+        "z": 4914
       },
       "max": {
-        "x": 3186,
-        "y": 4338,
-        "z": 6738
+        "x": 2514,
+        "y": 13746,
+        "z": 5170
       }
-    }
+    },
+    "resolution": {
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "type": 4,
+    "chunkDims": {
+      "x": 128,
+      "y": 128,
+      "z": 128
+    },
+    "vol_type": 2,
+    "mipLevel": 0
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -428,22 +428,45 @@ http://data.eyewire.org/volume/17096/chunk/0/1/1/0/mesh/2060
 # Response Objects
 
 ## Volume Object
-Contains an volume id and a [bounds object](#bounds-object). The bounds represents the area of space that the volume occupies.
+| Name            | Description                           |
+|:----------------|:--------------------------------------|
+| uri             | Path to file on server |
+| bounds          | [bounds object](#bounds-object)  |
+| resolution      | Always 1 for each dimension |
+| type            | One of the following: <ul><li>1: Signed Byte (-128 - 127)</li><li>2: Byte (0 - 255)</li><li>3: INT32 (signed 32-bit integer)</li><li>4: UINT32 (unsigned 32-bit integer, used for .png segmentation images)</li><li>5: FLOAT (used for .jpg channel images)</ul> |
+| chunkDims       | The size in voxels for each dimension of the chunk |
+| vol_type        | One of the following: <ul><li>1: Channel</li><li>2: Segmentation</li></ul> |
+| miplevel        | The MIP level of the images, always 0 |
 
 ### Example
 ```json
-"id": 63200,
-"bounds": {
-  "min": {
-    "x": 2930,
-    "y": 4082,
-    "z": 6482
+{
+  "uri": "/usr/local/omni/data/omelette2/x09/y59/x09y59z21_s2259_13491_4915_e2514_13746_5170.omni.files/",
+  "bounds": {
+    "min": {
+      "x": 2258,
+      "y": 13490,
+      "z": 4914
+    },
+    "max": {
+      "x": 2514,
+      "y": 13746,
+      "z": 5170
+    }
   },
-  "max": {
-    "x": 3186,
-    "y": 4338,
-    "z": 6738
-  }
+  "resolution": {
+    "x": 1,
+    "y": 1,
+    "z": 1
+  },
+  "type": 5,
+  "chunkDims": {
+    "x": 128,
+    "y": 128,
+    "z": 128
+  },
+  "vol_type": 1,
+  "mipLevel": 0
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,17 +38,17 @@ The EyeWire REST API provides programmatic access to interact with EyeWire's dat
 
 # EyeWire Structure & Terminology
 ## The Dataset
-The EyeWire dataset comprises pairs of .jpg from which we can map a 3D volume. EyeWire calls these images a `channel` and a `segmentation`. The images are grouped into `chunks`, which are then grouped into `volumes`.
+The EyeWire dataset comprises pairs of .jpg and .png images from which we can map a 3D volume. EyeWire calls the sets of .jpg images `channels` and the sets of .png images `segmentations`. The sets are grouped into `chunks`, which are then grouped into `volumes`.
 
 - `channel`
-    - an 8bpp greyscale .jpg file
+    - a set of 8bpp greyscale .jpg files
     - the electron microscope images
 - `segmentation`
-    - a .png file
+    - a set of 24bpp RGB .png files for normal `tasks` or 32bpp RGBA .png files for omni `tasks`
     - used to describe which pixels belong to which `segment` ID
-    - The RGBA color represents the `segment` ID: R + 256*G + 256^2 * B + 256^3 * A
-  `voxel`
-      the highest precision of the dataset. Can be considered a 1x1x1 pixel cube.
+    - The RGBA color represents the `segment` ID: R + 256*G + 256^2 * B + 256^3 * A. The alpha channel is excluded in non-omni `tasks`.
+- `voxel` 
+    - The highest precision of the dataset. Can be considered a 1x1x1 pixel cube.
 - `volume`
     - a 256^3 voxel cube
     - each `volume` overlaps its adjacent `volumes` by 32 voxels
@@ -61,7 +61,7 @@ The EyeWire dataset comprises pairs of .jpg from which we can map a 3D volume. E
     - a chunk contains 128 images for each of the three axis 'xy', 'yz', 'xz'
 
 ## Playing EyeWire (interacting with the dataset)
-When a user plays EyeWire they see the `channel` images and a 3D representation of the current `cell` they are attempting to map. This `cell` is located inside a specific `volume` and `chunk` (think of it like an address). The starting point of the `cell` the user is mapping is called a `seed`. There may be multiple `seeds` when a user begins mapping.
+When a user plays EyeWire they see the `channel` images and a 3D representation of a part of the current `cell` they are attempting to map. This part is located inside a specific `volume` and `chunk` (think of it like an address). The starting point of the part the user is mapping is called a `seed`. There may be multiple `seeds` when a user begins mapping.
 
 Providing the user with `seeds` for a `cell` is called assigning the player a `task`. As the user maps, they select `segments` they believe are attached to the `seeds`. When the user is done mapping the `task`, the `segments` the user selected are added to the task and create  a `validation`.
 
@@ -76,13 +76,13 @@ Providing the user with `seeds` for a `cell` is called assigning the player a `t
     - the pre-highlighted `segments` visible when a player begins a task
     - players select `segments` to group them with the `seeds`
 - `segment`:
-    - an group connected voxels that the EyeWire AI determined as belonging to the same cell
+    - a group of connected voxels that the EyeWire AI determined as belonging to a single branch of a cell
     - each `segment` has a unique identifier for its containing `volume`
 - `validation`
     - a `task` with a list of additional `segments`
-    - for example, a user starts playing EyeWire and receives a `task`. The user then highlights `segments` she believes are part of the `cell` that the initial `seeds` are part of. The resulting `task` is returned as a `validation`
+    - for example, a user starts playing EyeWire and receives a `task`. The user then highlights `segments` s/he believes are part of the `cell` that the initial `seeds` are part of. The resulting `task` is returned as a `validation`
 - `consensus`
-    - the current set of segments that are believed to belong a task based on user submitted validations
+    - the current set of `segments` that are believed to belong to a `task` based on user submitted `validations`
 
 ## Special things
 - `subspace`
@@ -92,7 +92,7 @@ Providing the user with `seeds` for a `cell` is called assigning the player a `t
 
 # Oauth2
 
-We use Oauth2 to allow EyeWire player's to share access to their account with your applications.To get an Oauth2 access token you must register an application.
+We use Oauth2 to allow EyeWire player's to share access to their account with your applications. To get an Oauth2 access token you must register an application.
 
 ## Registering an application
 An application requires a name and a redirection endpoint which is a url where you will receive auth codes and exchange them for access tokens.

--- a/README.md
+++ b/README.md
@@ -360,18 +360,18 @@ http://data.eyewire.org/volume/17096/chunk/0/1/1/0/mesh/2060
 ### Example Response
 ```
 0x0000: v1 vn1
-0x0008: v2 vn2
-0x0010: v3 vn3	# first triangle (1, 2, 3) complete
-0x0018: v4 vn4	# second triangle (2, 3, 4) complete
-0x0020: v5 vn5  # third triangle (3, 4, 5) complete
+0x0018: v2 vn2
+0x0030: v3 vn3	# first triangle (1, 2, 3) complete
+0x0048: v4 vn4	# second triangle (2, 3, 4) complete
+0x0060: v5 vn5  # third triangle (3, 4, 5) complete
 .
 .
 .
 ```
-
 * All values are Little Endian, 4 Byte `floats`.
 * v1 is the first vertex coordinate.
 * vn1 is the first vertex normal.
+* A vertex consists of three `floats` representing its X,Y,Z coordinates, in the given order.
 * Vertex Coordinates are within the range [0 .. 1]
 * Vertex Normals are normalized.
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ The EyeWire dataset comprises pairs of .jpg and .png images from which we can ma
     - a set of 8bpp greyscale .jpg files
     - the electron microscope images
 - `segmentation`
-    - a set of 24bpp RGB .png files for normal `tasks` or 32bpp RGBA .png files for omni `tasks`
+    - a set of 24bpp RGB .png files for normal `tasks`
     - used to describe which pixels belong to which `segment` ID
-    - The RGBA color represents the `segment` ID: R + 256*G + 256^2 * B + 256^3 * A. The alpha channel is excluded in non-omni `tasks`.
+    - The RGB color represents the `segment` ID: R + 256*G + 256^2 * B 
 - `voxel` 
     - The highest precision of the dataset. Can be considered a 1x1x1 pixel cube.
 - `volume`
@@ -295,7 +295,7 @@ https://beta.eyewire.org/2.0/tasks/assign?access_token=78q3ja8y
 }
 ```
 
-## POST 2.0/tasks/:id/save
+## POST 2.0/tasks/:id/submit
 
 Submit a validation for a task. The validation is used to calculate a consensus of the segments that belong to the task. The validation will be analyzed for accuracy and given a suggested score.
 

--- a/README.md
+++ b/README.md
@@ -197,13 +197,9 @@ The response contains volume objects that contain ids and bounds which are used 
 |:----------------|:------------------------------------|
 | id              | task id                             |
 | seeds           | array of segment ids known to be part of the cell.               |
-| status          | One of the following: <br/> <ul><li>0: NORMAL</li><li>3: TUTORIAL</li><li>6: STASHED (not visible in overview</li><li>10: FROZEN (unplayable)</li><li>11: DUPLICATE (all or part of this cube duplicates with another cube in a different cell)</li></ul>|
-| created         | The date and time when the task was created |
-| cell            | the ID of the cell that the task belongs to |
-| channel_id      | ID of the channel volume |
-| segmentation_id | ID of the segmentation volume |
-| channel         | channel [volume object](#volume-object)      |
-| segmentation    | segmentation [volume object](#volume-object) |
+| cell | the ID of the cell that the task belongs to |
+| channel      | channel [volume object](#volume-object)      |
+| segmentation | segmentation [volume object](#volume-object) |
 
 ### Error Responses
 - 404 - no tasks available that fulfill the request, try with a different cell_id or lack of one.
@@ -216,81 +212,38 @@ https://beta.eyewire.org/2.0/tasks/assign?access_token=78q3ja8y
 
 ```json
 {
-  "id": 558593,
-  "seeds": [ 491 ],
-  "status": 0,
-  "created": "2015-01-29T21:18:32.000Z",
-  "cell": 693,
-  "channel_id": 79285,
-  "segmentation_id": 79286,
-  "depth": 33,
-  "right_edge": 1444600,
-  "left_edge": 1444593,
-  "confidence": 1,
-  "underconfidence": 1,
-  "enabled": 1,
-  "weightsum": 0,
-  "lastmodified": "2015-02-04T21:26:28.000Z",
-  "flagged": 0,
-  "complete": 1,
-  "inspected_weight": 1,
-  "notes": "",
-  "completion_votes": 1000000,
+  "id": 17444,
+  "seeds": [245, 5025, 6500],
+  "cell": 10,
   "channel": {
-    "uri": "/usr/local/omni/data/omelette2/x09/y59/x09y59z21_s2259_13491_4915_e2514_13746_5170.omni.files/",
+    "id": 63200,
     "bounds": {
       "min": {
-        "x": 2258,
-        "y": 13490,
-        "z": 4914
+        "x": 2930,
+        "y": 4082,
+        "z": 6482
       },
       "max": {
-        "x": 2514,
-        "y": 13746,
-        "z": 5170
+        "x": 3186,
+        "y": 4338,
+        "z": 6738
       }
-    },
-    "resolution": {
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "type": 5,
-    "chunkDims": {
-      "x": 128,
-      "y": 128,
-      "z": 128
-    },
-    "vol_type": 1,
-    "mipLevel": 0
+    }
   },
-  "segmentation": {
-    "uri": "/usr/local/omni/data/omelette2/x09/y59/x09y59z21_s2259_13491_4915_e2514_13746_5170.omni.files/",
+  "segmentation":{
+    "id": 63201,
     "bounds": {
       "min": {
-        "x": 2258,
-        "y": 13490,
-        "z": 4914
+        "x": 2930,
+        "y": 4082,
+        "z": 6482
       },
       "max": {
-        "x": 2514,
-        "y": 13746,
-        "z": 5170
+        "x": 3186,
+        "y": 4338,
+        "z": 6738
       }
-    },
-    "resolution": {
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "type": 4,
-    "chunkDims": {
-      "x": 128,
-      "y": 128,
-      "z": 128
-    },
-    "vol_type": 2,
-    "mipLevel": 0
+    }
   }
 }
 ```
@@ -430,43 +383,23 @@ http://data.eyewire.org/volume/17096/chunk/0/1/1/0/mesh/2060
 ## Volume Object
 | Name            | Description                           |
 |:----------------|:--------------------------------------|
-| uri             | Path to file on server |
-| bounds          | [bounds object](#bounds-object)  |
-| resolution      | Always 1 for each dimension |
-| type            | One of the following: <ul><li>1: Signed Byte (-128 - 127)</li><li>2: Byte (0 - 255)</li><li>3: INT32 (signed 32-bit integer)</li><li>4: UINT32 (unsigned 32-bit integer, used for .png segmentation images)</li><li>5: FLOAT (used for .jpg channel images)</ul> |
-| chunkDims       | The size in voxels for each dimension of the chunk |
-| vol_type        | One of the following: <ul><li>1: Channel</li><li>2: Segmentation</li></ul> |
-| miplevel        | The MIP level of the images, always 0 |
+| id | Volume ID |
+| bounds | A [bounds object](#bounds-object), represents the area of space that the volume occupies |
 
 ### Example
 ```json
-{
-  "uri": "/usr/local/omni/data/omelette2/x09/y59/x09y59z21_s2259_13491_4915_e2514_13746_5170.omni.files/",
-  "bounds": {
-    "min": {
-      "x": 2258,
-      "y": 13490,
-      "z": 4914
-    },
-    "max": {
-      "x": 2514,
-      "y": 13746,
-      "z": 5170
-    }
+"id": 63200,
+"bounds": {
+  "min": {
+    "x": 2930,
+    "y": 4082,
+    "z": 6482
   },
-  "resolution": {
-    "x": 1,
-    "y": 1,
-    "z": 1
-  },
-  "type": 5,
-  "chunkDims": {
-    "x": 128,
-    "y": 128,
-    "z": 128
-  },
-  "vol_type": 1,
-  "mipLevel": 0
+  "max": {
+    "x": 3186,
+    "y": 4338,
+    "z": 6738
+  }
 }
 ```
 


### PR DESCRIPTION
The task assign example response was quite different from what the server was actually returning, so I changed that to reflect what the server responds with at the current time. Some of the values in the response aren't exactly known to me so those still have to be filled in.

The terminology had some incorrect parts in it and others which needed more description so I changed what I saw was wrong.
